### PR TITLE
Add SDL2 flag for linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: keyboard-tester
 
 CC=gcc
-LIBS=-lm $(shell sdl2-config --static-libs) -lSDL2_ttf
+LIBS=-lm $(shell sdl2-config --static-libs) -lSDL2 -lSDL2_ttf
 CFLAGS=-Wall -O2 $(shell sdl2-config --cflags)
 
 .c.o:


### PR DESCRIPTION
Didn't work on Manjaro without adding the `-lSDL2` flag.

I added it to the Makefile, everything works